### PR TITLE
prevent implicit type conversion

### DIFF
--- a/views/layouts/postlist/listshow.ejs
+++ b/views/layouts/postlist/listshow.ejs
@@ -19,7 +19,7 @@
     }
     nextPage = () => {
         let pages = document.getElementsByClassName('postpage');
-        if(index < pages.length - 1) setIndex(index + 1);
+        if(index < pages.length - 1) setIndex(index * 1 + 1); //prevent implicit type conversion
     }
 </script>
 
@@ -66,8 +66,10 @@
                             id='previousButton'
                             onclick='previousPage()'
                             style="margin:10px 0px 10px 10px; 
-                            padding: 5px 15px 5px 15px; width: 110px;">
-                            previous</button>
+                            padding: 5px 15px 5px 15px; width: 110px;"
+                        >
+                            previous
+                        </button>
                     </td>
                     <% for (let i = 0; i < Math.ceil(posts.length / 10); ++i) { %>
                     <td>
@@ -84,7 +86,8 @@
                             style="margin:10px 10px 10px 0px; 
                             padding: 5px 15px 5px 15px; width: 110px"
                         >
-                            N e x t</button>
+                            N e x t
+                        </button>
                     </td>
                 </tr>
             </tbody>


### PR DESCRIPTION
암시적 형 변환 방지

* js 특성 상 n + 1 이 숫자가 아닌 문자열로 반환 될 때가 있다. 이걸 막기 위해 n 에 먼저 1을 곱해서 무조건 숫자가 되게 했다.

- 저 코드로 수정하기 전에, 숫자버튼을 누른 후 next 버튼을 누르다보면 페이지가 출력되지 않는 버그가 발생한다.
- 이는 n + 1을 대입하는 과정에서 01, 11, 21 이 들어가기 때문. 명백한 오류다.